### PR TITLE
feat(commands/eval): the eval command now supports await keywords

### DIFF
--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -137,6 +137,15 @@ class Util {
   static getDevs() {
     return process.env.DEVS_IDS.split(',');
   }
+
+  /**
+   * Checks if something is a promise.
+   * @param {*} val The value to be checked.
+   * @returns {boolean} If the value was a promise.
+   */
+  static isPromise(val) {
+    return val && Object.prototype.toString.call(val) === '[object Promise]' && typeof val.then === 'function';
+  }
 }
 
 module.exports = Util;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Made the eval command send normal messages instead of embeds and it now supports asynchronous keywords.

**Status**
- [x] Code changes have been tested, or there are no code changes.

**Semantic versioning classification:**
- [ ] This PR adds a new command to the bot.
- [ ] This PR changes the bot's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
